### PR TITLE
Added RegistrationByConvention.FromAssembliesInSearchPath()

### DIFF
--- a/Unity.WebApi/RegistrationByConvention.cs
+++ b/Unity.WebApi/RegistrationByConvention.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security;
+
+namespace Unity.WebApi
+{
+    public static class RegistrationByConvention
+    {
+        public static IEnumerable<Type> FromAssembliesInSearchPath()
+        {
+            return GetTypes(GetAssembliesInSearchPath());
+        }
+
+        private static IEnumerable<Assembly> GetAssembliesInSearchPath()
+        {
+            try
+            {
+                string searchPath = (AppDomain.CurrentDomain.RelativeSearchPath == null)
+                    ? AppDomain.CurrentDomain.BaseDirectory
+                    : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AppDomain.CurrentDomain.RelativeSearchPath);
+
+                return Directory.EnumerateFiles(searchPath, "*.dll")
+                    .Select(x => LoadAssembly(Path.GetFileNameWithoutExtension(x)))
+                    .Where(x => x != null);
+            }
+            catch (SecurityException)
+            {
+                return new Assembly[0];
+            }
+        }
+
+        private static Assembly LoadAssembly(string assemblyName)
+        {
+            try
+            {
+                return Assembly.Load(assemblyName);
+            }
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
+            catch (FileLoadException)
+            {
+                return null;
+            }
+            catch (BadImageFormatException)
+            {
+                return null;
+            }
+        }
+
+        private static IEnumerable<Type> GetTypes(IEnumerable<Assembly> assemblies)
+        {
+            return assemblies.SelectMany(assembly =>
+            {
+                try
+                {
+                    return GetTypes(assembly.DefinedTypes);
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    return GetTypes(ex.Types
+                        .TakeWhile(x => x != null)
+                        .Select(x => x.GetTypeInfo()));
+                }
+            });
+        }
+
+        private static IEnumerable<Type> GetTypes(IEnumerable<TypeInfo> typeInfos)
+        {
+            return typeInfos
+                .Where(x => x.IsClass & !x.IsAbstract && !x.IsValueType && x.IsVisible)
+                .Select(ti => ti.AsType());
+        }
+    }
+}

--- a/Unity.WebApi/Unity.WebApi.csproj
+++ b/Unity.WebApi/Unity.WebApi.csproj
@@ -82,6 +82,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RegistrationByConvention.cs" />
     <Compile Include="UnityDependencyResolver.cs" />
     <Compile Include="UnityDependencyScope.cs" />
   </ItemGroup>


### PR DESCRIPTION
This is a replacement for Unity's own `AllClasses.FromAssembliesInBasePath()` which does not work with ASP.NET applications because it only looks at `AppDomain.CurrentDomain.BaseDirectory` and not `AppDomain.CurrentDomain.RelativeSearchPath`.

Related: [Stack Overflow: Unity 3 Configuration By Convention not finding Types in Web Project](http://stackoverflow.com/questions/22830345/unity-3-configuration-by-convention-not-finding-types-in-web-project)

I think this library would be a good fit for the code, since anybody combing Unity and WebAPI could run into this issue.
